### PR TITLE
feat: add parameter ui and debug mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ playhouse
 peewee
 pillow
 pyinstaller
+opencv-python

--- a/src/autodori.py
+++ b/src/autodori.py
@@ -14,6 +14,10 @@ from typing import Optional, Union
 
 import requests
 
+import cv2
+import tkinter as tk
+from tkinter import messagebox, simpledialog
+
 data_path = Path("data")
 data_path.mkdir(exist_ok=True)
 cache_path = Path("cache")
@@ -448,6 +452,61 @@ def wait_first_note():
             logging.error(f"Failed to get screen: {e}")
 
 
+def debug_ocr_song():
+    """Debug helper to OCR song name from a manually selected region."""
+    if maacontroller is None:
+        logging.error("MAA controller not initialized")
+        return
+    try:
+        # Capture screen using MAA controller
+        job = maacontroller.post_screencap()
+        result = job.wait()
+        if not result.succeeded:
+            logging.error("Failed to capture screen")
+            return
+        image = job.result  # numpy.ndarray
+
+        # Let user select ROI using OpenCV
+        roi = cv2.selectROI("OCR Song", image, False)
+        cv2.destroyWindow("OCR Song")
+        x, y, w, h = map(int, roi)
+        if w == 0 or h == 0:
+            logging.info("No region selected")
+            return
+
+        # Run OCR using MAA context
+        context = Context(maatasker._handle)
+        pipeline = {
+            "_debug_song_ocr": {
+                "recognition": "OCR",
+                "only_rec": True,
+                "roi": [x, y, w, h],
+                "model": "ppocr_v5/zh_cn",
+            }
+        }
+        ocr_result = context.run_recognition("_debug_song_ocr", image, pipeline)
+        song_name = ocr_result.best_result.text.strip()
+
+        # Show dialog to edit song name
+        root = tk.Tk()
+        root.withdraw()
+        song_name = simpledialog.askstring("OCR歌曲", "读取到的歌名", initialvalue=song_name)
+        if not song_name:
+            return
+
+        match_name, _ = fuzzy_match_song(song_name)
+        if match_name is None:
+            messagebox.showerror("错误", "未找到匹配歌曲")
+            return
+        save_song(match_name)
+
+        if messagebox.askyesno("开始打歌", f"歌曲: {match_name}\n难度: {DIFFICULTY}"):
+            play_song()
+        else:
+            messagebox.showinfo("提示", "已取消")
+    except Exception as e:
+        logging.error(f"Debug OCR failed: {e}")
+
 def init_maa():
     # 修改：增加 global 声明
     global game_package_name, chosen_resource_name
@@ -649,9 +708,10 @@ def init_player_and_mnt():
     logging.info("Mumu and MNT inited.")
 
 
-def configure_log():
+def configure_log(debug: bool = False):
+    level = logging.DEBUG if debug else logging.INFO
     logging.basicConfig(
-        level=logging.DEBUG,
+        level=level,
         format="%(asctime)s[%(levelname)s][%(name)s] %(message)s",
         handlers=[
             logging.StreamHandler(),
@@ -787,10 +847,8 @@ def check_update():
 
 
 def main():
-    configure_log()
-
     parser = argparse.ArgumentParser(
-        description="AutoDori script with different modes."
+        description="AutoDori script with different modes.",
     )
     parser.add_argument(
         "--mode",
@@ -824,7 +882,25 @@ def main():
         action="store_true",
         help="Specify if skip version check",
     )
+    parser.add_argument(
+        "--ui",
+        action="store_true",
+        help="Launch graphical interface for parameter selection",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug output",
+    )
     args = parser.parse_args()
+
+    configure_log(debug=args.debug)
+
+    if args.ui:
+        from gui import run_ui
+
+        run_ui()
+        return
 
     if args.mode == "main":
         entry = "main"

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,0 +1,128 @@
+import sys
+import signal
+import subprocess
+import threading
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk, scrolledtext
+
+import autodori
+
+
+def run_ui():
+    autodori.init_maa()
+    autodori.init_player_and_mnt()
+
+    root = tk.Tk()
+    root.title("Autodori UI")
+
+    difficulty_var = tk.StringVar(value="hard")
+    livemode_var = tk.StringVar(value="freelive")
+    liveboost_var = tk.IntVar(value=1)
+    debug_var = tk.BooleanVar(value=False)
+
+    process = None
+
+    def start():
+        nonlocal process
+        if process and process.poll() is None:
+            return
+        cmd = [
+            sys.executable,
+            str(Path(autodori.__file__).resolve()),
+            "--mode",
+            "main",
+            "--difficulty",
+            difficulty_var.get(),
+            "--livemode",
+            livemode_var.get(),
+            "--liveboost",
+            str(liveboost_var.get()),
+        ]
+        if debug_var.get():
+            cmd.append("--debug")
+        text_area.delete("1.0", tk.END)
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE if debug_var.get() else None,
+            stderr=subprocess.STDOUT if debug_var.get() else None,
+            text=True,
+        )
+        if debug_var.get():
+            def reader():
+                for line in process.stdout:
+                    text_area.insert(tk.END, line)
+                    text_area.see(tk.END)
+            threading.Thread(target=reader, daemon=True).start()
+
+    def stop():
+        nonlocal process
+        if process and process.poll() is None:
+            try:
+                process.send_signal(signal.SIGINT)
+                process.wait(timeout=5)
+            except Exception:
+                process.kill()
+        process = None
+
+    def toggle_debug():
+        if debug_var.get():
+            debug_frame.grid()
+        else:
+            debug_frame.grid_remove()
+
+    def do_ocr():
+        autodori.debug_ocr_song()
+
+    frm = ttk.Frame(root, padding=10)
+    frm.grid()
+
+    ttk.Label(frm, text="Difficulty").grid(row=0, column=0, sticky="w")
+    ttk.OptionMenu(
+        frm,
+        difficulty_var,
+        difficulty_var.get(),
+        "easy",
+        "normal",
+        "hard",
+        "expert",
+        "special",
+    ).grid(row=0, column=1, sticky="ew")
+
+    ttk.Label(frm, text="Live Mode").grid(row=1, column=0, sticky="w")
+    ttk.OptionMenu(
+        frm,
+        livemode_var,
+        livemode_var.get(),
+        "freelive",
+        "challengelive",
+    ).grid(row=1, column=1, sticky="ew")
+
+    ttk.Label(frm, text="Min Live Boost").grid(row=2, column=0, sticky="w")
+    ttk.Spinbox(frm, from_=1, to=10, textvariable=liveboost_var, width=5).grid(
+        row=2, column=1, sticky="w"
+    )
+
+    ttk.Checkbutton(
+        frm, text="Debug Mode", variable=debug_var, command=toggle_debug
+    ).grid(row=3, column=0, columnspan=2, sticky="w")
+
+    ttk.Button(frm, text="Start", command=start).grid(row=4, column=0, pady=5)
+    ttk.Button(frm, text="Stop", command=stop).grid(row=4, column=1, pady=5)
+
+    ttk.Button(frm, text="OCR歌曲", command=do_ocr).grid(
+        row=5, column=0, columnspan=2, pady=5
+    )
+
+    debug_frame = ttk.Frame(root, padding=10)
+    debug_frame.grid(row=1, column=0, sticky="nsew")
+    text_area = scrolledtext.ScrolledText(debug_frame, width=80, height=20)
+    text_area.pack()
+    debug_frame.grid_remove()
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    autodori.configure_log(debug=True)
+    run_ui()


### PR DESCRIPTION
## Summary
- add `--ui` switch launching a Tkinter interface for difficulty, mode and live-boost selection
- support `--debug` to enable detailed OCR/image match logging and stream it back to the UI
- expand debug GUI into a full controller with start/stop and live log output

## Testing
- `pre-commit run --files src/autodori.py src/gui.py`
- `python -m py_compile src/autodori.py src/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a572b6d0ec83289969be8c3cadf56c